### PR TITLE
Update README for ST3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Archive of pre-compiled PyV8 binaries, used by Emmet for Sublime Text plugin.
 If you experience issues with automatic PyV8 download of [Emmet for Sublime Text plugin](https://github.com/sergeche/emmet-sublime), you can manually install it:
 
 1. Download PyV8 binary for your OS version (see notes below).
-2. Unpack contents of downloaded archive into `PyV8/%filename%` folder inside Sublime Text Packages (find `Browse Packages...` menu item in ST2 editor to get into Packages folder), where `%filename%` is the name of downloaded file (e.g. it will be `pyv8-win64-p3` if you download `pyv8-win64-p3.zip` file).
-3. Restart ST editor.
+2. For Sublime Text 2 Unpack contents of downloaded archive into `PyV8/%filename%` folder inside Sublime Text Packages (find `Browse Packages...` menu item in ST2 editor to get into Packages folder), where `%filename%` is the name of downloaded file (e.g. it will be `pyv8-win64-p3` if you download `pyv8-win64-p3.zip` file).
+3. For Sublime Text 3 Unpack contents of downloaded archive into `PyV8/%filename%` folder inside Sublime Text Installed Packages (find `Browse Packages...` menu item under preferences in ST3 editor to get into Packages folder, go up one level and go into Installed Packages), where `%filename%` is the name of downloaded file (e.g. it will be `pyv8-win64-p3` if you download `pyv8-win64-p3.zip` file).
+4. Restart ST editor.
 
 ## Download
 


### PR DESCRIPTION
Sublime Text 3 searches pyv8 binaries in Installed Packages folder rather than Packages folder.